### PR TITLE
Version 0.0.2. Support Server Sent Event.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # The server implementation which supports both HTTP/1 and HTTP/2
+This server is not intended for production use.
+I implement this server to understand how low-level web works, low-level HTTP protocol works and Etc.   
+
 
 ### VERSION
 - 0.0.0 : skeleton. (HTTP/1, HTTP/2 with h2c protocol)
@@ -8,6 +11,72 @@
   - Support Virtual server by port and domain by. 
   - Change interface of using route rule.
   - Fixes bug that can't response completely when there is no route rule at all.
+- 0.0.2
+  - Support Server Sent Event Feature with HTTP/1.1. 
+
+### How to use
+```python
+import asyncio
+import time
+
+from http_2.server import Server, AsyncServerExecutor
+from http_2.ssl_object import SSLConfig
+from http_2.common_http_object import GenericHttpRequest, GenericHttpResponse
+from http_2.http1_response import StreamingResponse, GeneralHttp1Response
+
+async def main():
+
+    localhost_ssl_config = SSLConfig()
+    localhost_ssl_config.add_tls_with_hostname(
+        hostname='localhost',
+        certfile_path='...',
+        keyfile_path='...')
+
+    example_com_ssl_config = SSLConfig()
+    example_com_ssl_config.add_tls_with_hostname(
+        hostname='example.com',
+        certfile_path='...',
+        keyfile_path='...')
+
+    http_localhost_server = Server(8080)
+    localhost_server = Server(443, hostname='localhost', ssl_config=localhost_ssl_config)
+    example_com_server = Server(443, hostname='example.com', ssl_config=example_com_ssl_config)
+
+    @http_localhost_server.get_mapping(path='/sse')
+    async def server_sent_event(http_request: GenericHttpRequest, http_response: GenericHttpResponse):
+        async def gen_events():
+            for _ in range(5):
+                await asyncio.sleep(1)
+                yield f"data: 현재 시간은 {time.strftime('%Y-%m-%d %H:%M:%S')}\n"
+
+        return StreamingResponse(gen_events())
+
+    @http_localhost_server.route(path='/', methods=['POST', 'GET'])
+    @example_com_server.route(path='/', methods=['POST', 'GET'])
+    @localhost_server.route(path='/', methods=['POST', 'GET'])
+    async def common(http_request: GenericHttpRequest, http_response: GenericHttpResponse):
+        return GeneralHttp1Response(body='hello')
+
+    executor = AsyncServerExecutor()
+    executor.add_server(http_localhost_server)
+    executor.add_server(localhost_server)
+    executor.add_server(example_com_server)
+
+    async with executor:
+        await executor.execute_forever()
+
+if __name__ == '__main__':
+    asyncio.run(main())
+```
+
+### How to test
+
+#### For Unit and Integration Test
+```shell
+$ py.test ./tests/
+```
+
+#### For HTTP/2 Spec test
 
 ```shell
 $ brew install h2spec
@@ -35,29 +104,6 @@ HPACK: Header Compression for HTTP/2
 
 Finished in 0.2501 seconds
 146 tests, 145 passed, 1 skipped, 0 failed
-```
-
-
-
-## How to use.
-```python
-import asyncio
-from server import HttpServerDispatcher, Server
-from generic_http_object import GenericHttpRequest, GenericHttpResponse
-from status_code import StatusCode
-
-@HttpServerDispatcher.route(path='/hello/ballo', methods=['POST', 'GET'])
-async def return_ok(http_request: GenericHttpRequest, http_response: GenericHttpResponse):
-    print('return_ok called.')
-    http_response.status_code = StatusCode.OK
-    http_response.body = 2
-    return http_response
-
-
-async def main():
-    server = Server(host='0.0.0.0', port=8080)
-    await server.serve_forever()
-
 ```
 
 

--- a/http_2/common_http_object.py
+++ b/http_2/common_http_object.py
@@ -3,8 +3,8 @@ import base64
 from hyperframe.frame import SettingsFrame
 from typing import Union, Optional, Literal, Any
 
-from status_code import StatusCode
-from http2_object import Http2Stream
+from http_2.status_code import StatusCode
+from http_2.http2_object import Http2Stream
 
 
 class Http1Request:
@@ -56,43 +56,48 @@ class Http1Request:
         return query_params_dict
 
 
-class Http1Response:
-
-    @staticmethod
-    def init_http1_response():
-        return Http1Response(StatusCode.OK, {}, '')
-
-    def __init__(self,
-                 status_code: StatusCode,
-                 headers: dict[str, Union[any, str]],
-                 body: str):
-
-        self._status_code = status_code
-        self._headers = headers
-        self._body = body
-
-    @property
-    def status_code(self):
-        return self._status_code
-
-    @status_code.setter
-    def status_code(self, status_code: StatusCode):
-        self._status_code = status_code
-
-    @property
-    def headers(self):
-        return self._headers
-
-    def update_headers(self, header: dict):
-        self._headers.update(header)
-
-    @property
-    def body(self):
-        return self._body
-
-    @body.setter
-    def body(self, body: str):
-        self._body = str(body)
+# class Http1Response:
+#
+#     @staticmethod
+#     def init_http1_response():
+#         return Http1Response(StatusCode.OK, {}, '')
+#
+#     def __init__(self,
+#                  status_code: StatusCode,
+#                  headers: dict[str, Union[any, str]],
+#                  body: str):
+#
+#         self._status_code = status_code
+#         self._headers = headers
+#         self._body = body
+#         self._protocol = 'HTTP/1.1'
+#
+#     @property
+#     def protocol(self):
+#         return self._protocol
+#
+#     @property
+#     def status_code(self):
+#         return self._status_code
+#
+#     @status_code.setter
+#     def status_code(self, status_code: StatusCode):
+#         self._status_code = status_code
+#
+#     @property
+#     def headers(self):
+#         return self._headers
+#
+#     def update_headers(self, header: dict):
+#         self._headers.update(header)
+#
+#     @property
+#     def body(self):
+#         return self._body
+#
+#     @body.setter
+#     def body(self, body: str):
+#         self._body = str(body)
 
 
 class Http2Request:
@@ -240,7 +245,6 @@ class GenericHttpResponse:
         self._headers = headers
         self._body = str(body)
 
-
     @property
     def status_code(self):
         return self._status_code
@@ -289,8 +293,6 @@ class GenericHttpToHttp2ResponseConverter:
             original_response.headers,
             original_response.body
         )
-
-
 
 
 class NeedtoResponseException(Exception):
@@ -346,16 +348,16 @@ class NeedToChangeProtocol:
     SETTINGS Frame {
       Length (24),
       Type (8) = 0x04,
-    
+
       Unused Flags (7),
       ACK Flag (1),
-    
+
       Reserved (1),
       Stream Identifier (31) = 0,
-    
+
       Setting (48) ...,
     }
-    
+
     Setting {
       Identifier (16), (2 bytes)
       Value (32), (4 bytes)

--- a/http_2/http1_response.py
+++ b/http_2/http1_response.py
@@ -1,0 +1,264 @@
+from abc import abstractmethod, ABC
+from asyncio.streams import StreamWriter
+from typing import AsyncIterable, cast
+
+from http_2.status_code import StatusCode
+
+class Response(ABC):
+
+    @property
+    @abstractmethod
+    def protocol(self):
+        pass
+
+    @property
+    @abstractmethod
+    def status_code(self):
+        pass
+
+    @property
+    @abstractmethod
+    def headers(self):
+        pass
+
+    @property
+    @abstractmethod
+    def body(self):
+        pass
+
+    @abstractmethod
+    def has_body(self):
+        pass
+
+
+class GeneralHttp1Response(Response):
+
+    def __init__(self,
+                 status_code: StatusCode = StatusCode.OK,
+                 headers: dict[str, str] | None = None,
+                 body: str = ''):
+        self._protocol = 'HTTP/1.1'
+        self._status_code = status_code
+        self._headers = {} if headers is None else headers
+        self._body = body
+
+        if body:
+            header_for_body = {
+                'Content-Type': 'text/plain',
+                'Content-length': str(len(body))
+            }
+            self._headers.update(header_for_body)
+        else:
+            header_for_body = {
+                'Content-length': '0'
+            }
+            self._headers.update(header_for_body)
+
+    @property
+    def protocol(self):
+        return self._protocol
+
+    @property
+    def status_code(self):
+        return self._status_code
+
+    @property
+    def headers(self):
+        return self._headers
+
+    @property
+    def body(self):
+        return self._body
+
+    def has_body(self):
+        return len(self._body) > 0
+
+
+class StreamingResponse(Response):
+
+    def __init__(self,
+                 contents_generator: AsyncIterable,
+                 status_code: StatusCode = StatusCode.OK,
+                 headers: dict[str, str] | None = None,
+                 media_type: str = 'text/event-stream',
+                 char_set: str = 'utf-8'
+                 ):
+
+        self._body_iterator = contents_generator
+        self._status_code = status_code
+        self._headers = {} if headers is None else headers
+        self._media_type = media_type
+        self._char_set = char_set
+        self._protocol = 'HTTP/1.1'
+        self._encoding = 'utf-8'
+
+        if media_type == 'text/event-stream':
+            headers = {
+                'Content-Type': 'text/event-stream',
+                'Transfer-Encoding': 'chunked',
+                'Cache-Control': 'no-cache'
+            }
+            self._headers.update(headers)
+
+    async def next_response(self):
+        async for chunk in self._body_iterator:
+            return chunk
+        return ''
+
+    @property
+    def protocol(self):
+        return self._protocol
+
+    @property
+    def status_code(self):
+        return self._status_code
+
+    @property
+    def encoding(self):
+        return self._encoding
+
+    @property
+    def headers(self):
+        return self._headers
+
+    @property
+    def body(self):
+        raise NotImplemented('Not Implemented. because body is async generator')
+
+    @property
+    def has_body(self):
+        raise NotImplemented('Not Implemented. because body is async generator')
+
+# Chunked encoding 헤더에는 Transfer-Encoding: chunked가 표시되고, 본문은 chunk size+내용+chunk size+내용... 형식으로 표시된다.
+# Trasfer-Encoding = chunked
+#
+
+class AbstractHttp1ResponseWriter(ABC):
+
+    async def write(self, response: Response):
+        await self._write_status_line(response)
+        await self._write_header_lines(response)
+        await self._write_body(response)
+
+    @abstractmethod
+    async def _write_status_line(self, response: Response):
+        pass
+
+    @abstractmethod
+    async def _write_header_lines(self, response: Response):
+        pass
+
+    @abstractmethod
+    async def _write_body(self, response: Response):
+        pass
+
+    def get_extra_info(self, key: str):
+        if hasattr(self, '_writer'):
+            writer = getattr(self, '_writer')
+            writer = cast(StreamWriter, writer)
+            return writer.transport.get_extra_info(key)
+        return None
+
+
+class Http1ResponseWriter(AbstractHttp1ResponseWriter):
+
+    def __init__(self, writer: StreamWriter):
+        self._writer = writer
+
+    async def write(self, response: Response):
+        await self._write_status_line(response)
+        await self._write_header_lines(response)
+        await self._write_body(response)
+
+    async def _write_status_line(self, response: Response):
+        http_protocol = response.protocol
+        status_code = response.status_code.status_code
+        status_code_text = response.status_code.text
+
+        status_line = ' '.join(map(lambda x: str(x), [http_protocol, status_code, status_code_text])) + '\r\n'
+        encoded_status_line = status_line.encode()
+        self._writer.write(encoded_status_line)
+        await self._writer.drain()
+
+    async def _write_header_lines(self, response: Response):
+        header_lines = ''
+
+        for header_key, header_value in response.headers.items():
+            header_line = f'{header_key}: {header_value}\r\n'
+            header_lines += header_line
+
+        header_lines += '\r\n'
+        encoded_header_lines = header_lines.encode()
+        self._writer.write(encoded_header_lines)
+        await self._writer.drain()
+
+    @abstractmethod
+    async def _write_body(self, response: Response):
+        pass
+
+    def get_extra_info(self, key: str):
+        if hasattr(self, '_writer'):
+            writer = getattr(self, '_writer')
+            writer = cast(StreamWriter, writer)
+            return writer.transport.get_extra_info(key)
+        return None
+
+
+class GeneralResponseWriter(Http1ResponseWriter):
+
+    def __init__(self, writer: StreamWriter):
+        super().__init__(writer)
+        self._writer: StreamWriter = writer
+
+    async def write(self, response: GeneralHttp1Response):
+        await self._write_status_line(response)
+        await self._write_header_lines(response)
+        await self._write_body(response)
+
+    async def _write_status_line(self, response: GeneralHttp1Response):
+        await super()._write_status_line(response)
+
+    async def _write_header_lines(self, response: GeneralHttp1Response):
+        await super()._write_header_lines(response)
+
+    async def _write_body(self, response: GeneralHttp1Response):
+        encoded_body = response.body.encode('utf-8') if response.body else b'\r\n'
+        self._writer.write(encoded_body)
+        await self._writer.drain()
+
+    async def wait_closed(self):
+        self._writer.close()
+        await self._writer.wait_closed()
+
+
+class ChunkedResponseWriter(Http1ResponseWriter):
+
+    def __init__(self, writer: StreamWriter):
+        super().__init__(writer)
+        self._writer = writer
+
+    async def write(self, http_response: StreamingResponse):
+        await self._write_status_line(http_response)
+        await self._write_header_lines(http_response)
+        await self._write_body(http_response)
+
+    async def _write_status_line(self, response: StreamingResponse):
+        await super()._write_status_line(response)
+
+    async def _write_header_lines(self, response: StreamingResponse):
+        await super()._write_header_lines(response)
+
+    async def _write_body(self, response: StreamingResponse):
+        while True:
+            body = await response.next_response()
+            body = str(body)
+            if not body:
+                self._writer.write(b'0\r\n\r\n')
+                await self._writer.drain()
+                break
+
+            encoded_body = body.encode()
+            # Chunk size should be hex type. note -> :x
+            encoded_length = f"{len(encoded_body):x}".encode(response.encoding)
+            self._writer.write(encoded_length + b'\r\n' + encoded_body + b'\r\n')
+            await self._writer.drain()

--- a/http_2/http2_connection.py
+++ b/http_2/http2_connection.py
@@ -1,20 +1,19 @@
 import asyncio
-from asyncio.streams import StreamReader, StreamWriter
-
 import hyperframe.frame
+
+from asyncio.streams import StreamReader, StreamWriter
 from hyperframe.frame import Frame, SettingsFrame, PriorityFrame, HeadersFrame, DataFrame, PushPromiseFrame, PingFrame, WindowUpdateFrame, GoAwayFrame, ContinuationFrame, RstStreamFrame, ExtensionFrame
 from hpack import Decoder, Encoder
-
 from typing import Self, Union, Optional, Callable
 
-from exception import NeedToChangeProtocolException
-from flags import END_STREAM, END_HEADERS
-from interface import Http2ConnectionInterface
-from error_code import StreamErrorCode
-from http2_exception import Http2ConnectionError, StopConnectionException, SettingsValueException
-from http2_object import Http2Stream, Http2StreamQueue, Http2Settings, AsyncGenerator, TerminateAwareAsyncioQue
-from generic_http_object import Http2Request, GenericHttpRequest, Http2ToGenericHttpRequestConverter, GenericHttpResponse, GenericHttpToHttp2ResponseConverter, Http2Response
-from status_code import StatusCode
+from http_2.exception import NeedToChangeProtocolException
+from http_2.flags import END_STREAM, END_HEADERS
+from http_2.interface import Http2ConnectionInterface
+from http_2.error_code import StreamErrorCode
+from http_2.http2_exception import Http2ConnectionError, StopConnectionException, SettingsValueException
+from http_2.http2_object import Http2Stream, Http2StreamQueue, Http2Settings, AsyncGenerator, TerminateAwareAsyncioQue
+from http_2.common_http_object import Http2Request, GenericHttpRequest, Http2ToGenericHttpRequestConverter, GenericHttpResponse, GenericHttpToHttp2ResponseConverter, Http2Response
+from http_2.status_code import StatusCode
 
 from frame_handler import HANDLER_STORE, HandlerStore
 

--- a/http_2/http2_exception.py
+++ b/http_2/http2_exception.py
@@ -1,26 +1,30 @@
 from hyperframe.frame import Frame
 
+
 class HeaderValidateException(Exception):
 
     def __init__(self, response_frame: Frame, msg: str):
         self.response_frame = response_frame
         self.msg = msg
 
+
 class SettingsValueException(Exception):
 
     def __init__(self, response_frame: Frame):
         self.response_frame = response_frame
 
+
 class StopNextException(Exception):
     pass
+
 
 class StopConnectionException(Exception):
 
     def __init__(self, msg):
         self.msg = msg
 
-class Http2ConnectionError(Exception):
 
+class Http2ConnectionError(Exception):
 
     def __init__(self, msg):
         self.msg = msg

--- a/http_2/http2_object.py
+++ b/http_2/http2_object.py
@@ -2,12 +2,11 @@ import uuid
 import asyncio
 
 from typing import Union
-
 from hyperframe.frame import Frame, SettingsFrame, PriorityFrame, HeadersFrame, DataFrame, PushPromiseFrame, PingFrame, WindowUpdateFrame, GoAwayFrame, ContinuationFrame, RstStreamFrame, ExtensionFrame
 from collections import deque
 
-from http2_exception import HeaderValidateException, SettingsValueException
-from error_code import StreamErrorCode
+from http_2.http2_exception import HeaderValidateException, SettingsValueException
+from http_2.error_code import StreamErrorCode
 
 # https://datatracker.ietf.org/doc/html/rfc9113#name-stream-states
 class Http2StreamState:

--- a/http_2/interface.py
+++ b/http_2/interface.py
@@ -1,7 +1,8 @@
 from hyperframe.frame import Frame
 from typing import Callable
-from error_code import StreamErrorCode
-from http2_object import Http2Stream
+
+from http_2.error_code import StreamErrorCode
+from http_2.http2_object import Http2Stream
 
 class ConnectionInterface:
     async def update_window_size(self, frame: Frame):

--- a/http_2/main.py
+++ b/http_2/main.py
@@ -1,8 +1,11 @@
 import asyncio
-from server import Server, AsyncServerExecutor
-from ssl_object import SSLConfig
-from generic_http_object import GenericHttpRequest, GenericHttpResponse
-from status_code import StatusCode
+import time
+
+from http_2.server import Server, AsyncServerExecutor
+from http_2.ssl_object import SSLConfig
+from http_2.common_http_object import GenericHttpRequest, GenericHttpResponse
+from http_2.http1_response import StreamingResponse, GeneralHttp1Response
+from http_2.status_code import StatusCode
 
 async def main():
 
@@ -30,6 +33,29 @@ async def main():
         http_response.status_code = StatusCode.OK
         http_response.body = 2
         return http_response
+
+    # for the test.
+    @http_localhost_server.route(path='/', methods=['POST', 'GET'])
+    @example_com_server.route(path='/', methods=['POST', 'GET'])
+    @localhost_server.route(path='/', methods=['POST', 'GET'])
+    async def return_t(http_request: GenericHttpRequest, http_response: GenericHttpResponse):
+        print('return_ok called.')
+        http_response.status_code = StatusCode.OK
+        http_response.body = 2
+        return http_response
+
+    @http_localhost_server.get_mapping(path='/sse')
+    async def sse(http_request: GenericHttpRequest, http_response: GenericHttpResponse):
+        async def gen_events():
+            for _ in range(5):
+                await asyncio.sleep(1)
+                yield f"data: 현재 시간은 {time.strftime('%Y-%m-%d %H:%M:%S')}\n"
+
+        return StreamingResponse(gen_events())
+
+    @http_localhost_server.get_mapping(path='/common')
+    async def common(http_request: GenericHttpRequest, http_response: GenericHttpResponse):
+        return GeneralHttp1Response(body='hello')
 
     executor = AsyncServerExecutor()
     executor.add_server(http_localhost_server)

--- a/http_2/protocol/SERVER_SENT_EVENT.MD
+++ b/http_2/protocol/SERVER_SENT_EVENT.MD
@@ -1,0 +1,35 @@
+## Server Sent Event protocol
+- SSE는 HTTP/1.1, HTTP/2 RFC에 명시된 프로토콜은 아니다.
+
+### 응답 시, 필요한 것들
+- 응답 헤더
+  - Content-Type: text/event-stream
+  - Transfer-Encoding: Chunked
+- 응답 Chunk
+  - `([CHUNK_SIZE:16진수]\r\n[CONTENTS]\r\n).encode()`
+
+
+
+
+```mermaid
+    sequenceDiagram
+        
+    actor Client
+    actor Server
+    autonumber
+    
+    Client ->>+ Server : Send HTTP/1.1 Request.
+    Server -->> Client : Send response which content type is text/event-stream
+    Server -->> Client : Send first chunk (b'1\r\na\r\n') -> Chunk Size = 1, Contents = a
+    Server -->> Client : Send first chunk (b'1\r\nbc\r\n') -> Chunk Size = 2, Contents = bc
+    Server -->>- Client : Send first chunk (b'0\r\n\r\n') -> Chunk Size = 0 (End Chunk)
+    
+    Server ->> Client: Close Connection.
+    Client ->> Server: Close Connection.
+```
+- 클라이언트는 서버에게 요청을 보냄. 
+- 서버는 클라이언트에 `Content-Type: text/event-stream`을 응답함.
+- 서버는 Connection을 닫지 않은 채, 클라이언트에게 Chunk 단위로 메세지를 전송.
+  - Format은 다음과 같음 -> `<CHUNK_SIZE:16진수>\r\n<Encoded Contents>\r\n`
+  - 더 이상 보낼 것이 없는 경우 -> `<0:16진수>\r\n\r\n`
+- 서버 / 클라이언트는 커넥션을 닫는다.

--- a/http_2/protocol_verifier.py
+++ b/http_2/protocol_verifier.py
@@ -1,6 +1,7 @@
 from asyncio.streams import StreamReader, StreamWriter
 from typing import Tuple
-from exception import UnknownProtocolException
+
+from http_2.exception import UnknownProtocolException
 
 
 class ProtocolVerifier:

--- a/http_2/server.py
+++ b/http_2/server.py
@@ -3,14 +3,14 @@ import asyncio
 from asyncio.streams import StreamReader, StreamWriter
 from typing import Callable
 
-from protocol_verifier import ProtocolVerifier
-from data_structure import Trie
-from exception import UnknownProtocolException, NeedToChangeProtocolException
-from http1_connection import Http1Connection
-from http2_connection import Http2Connection
-from generic_http_object import GenericHttpRequest, GenericHttpResponse, NeedToChangeProtocol
-from status_code import StatusCode
-from ssl_object import SSLConfig, IntegrateSSLConfig
+from http_2.protocol_verifier import ProtocolVerifier
+from http_2.data_structure import Trie
+from http_2.exception import UnknownProtocolException, NeedToChangeProtocolException
+from http_2.http1_connection import Http1Connection
+from http_2.http2_connection import Http2Connection
+from http_2.common_http_object import GenericHttpRequest, GenericHttpResponse, NeedToChangeProtocol
+from http_2.status_code import StatusCode
+from http_2.ssl_object import SSLConfig, IntegrateSSLConfig
 
 
 class Server:
@@ -64,6 +64,8 @@ class Server:
             http_response.status_code = StatusCode.NOT_FOUND
             return http_request, http_response
         else:
+            # TODO : 이걸 이용하면 Argument Resolve 가능함.
+            # func.__code__.co_varnames
             response = await func(http_request, http_response)
             return http_request, response
 

--- a/http_2/tests/test_http1_common.py
+++ b/http_2/tests/test_http1_common.py
@@ -1,0 +1,118 @@
+import asyncio
+import pytest
+import socket
+
+from http_2.common_http_object import GenericHttpRequest, GenericHttpResponse
+from http_2.status_code import StatusCode
+from http_2.http1_response import GeneralHttp1Response
+from http_2.server import Server, AsyncServerExecutor
+
+RETURN_RESULT = '/HELLO_CALLED!'
+RESULT_400 = 'Invalid Request'
+
+@pytest.fixture
+def server_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(('', 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture
+async def server(server_port):
+    http_localhost_server = Server(server_port)
+
+    @http_localhost_server.route(path='/hello', methods=['GET', 'POST'])
+    async def return_ok(http_request: GenericHttpRequest, http_response: GenericHttpResponse):
+        return GeneralHttp1Response(status_code=StatusCode.OK, body=RETURN_RESULT + http_request.body)
+
+    @http_localhost_server.route(path='/400', methods=['GET', 'POST'])
+    async def return_400(http_request: GenericHttpRequest, http_response: GenericHttpResponse):
+        return GeneralHttp1Response(status_code=StatusCode.BAD_REQUEST, body=RESULT_400)
+
+    executor = AsyncServerExecutor()
+    executor.add_server(http_localhost_server)
+
+    await executor.__aenter__()
+    t = asyncio.create_task(executor.execute_forever())
+    await asyncio.sleep(1)
+    yield t
+
+    await executor.__aexit__('', '', '')
+    try:
+        t.cancel()
+        await t
+    except asyncio.CancelledError:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_should_receive_200_with_get(server_port, server):
+    # Given
+    cmds = ['curl',
+            f'http://localhost:{server_port}/hello',
+            '-vvv',
+            ]
+    expected_response = RETURN_RESULT
+
+    # When
+    process = await asyncio.create_subprocess_exec(
+        *cmds,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE
+    )
+
+    # Then
+    stdout, stderr = await process.communicate()
+
+    assert stdout.decode() == expected_response
+    assert 'HTTP/1.1 200 OK' in stderr.decode()
+
+
+@pytest.mark.asyncio
+async def test_should_receive_200_with_post_and_body(server_port, server):
+    # Given
+    req_body = 'HI'
+    cmds = ['curl',
+            f'http://localhost:{server_port}/hello',
+            '-vvv',
+            '-d', req_body
+            ]
+
+    expected_response = RETURN_RESULT + req_body
+
+    # When
+    process = await asyncio.create_subprocess_exec(
+        *cmds,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE
+    )
+
+    # Then
+    stdout, stderr = await process.communicate()
+
+    assert stdout.decode() == expected_response
+    assert 'HTTP/1.1 200 OK' in stderr.decode()
+
+@pytest.mark.asyncio
+async def test_should_receive_400_with_get(server_port, server):
+    # Given
+    req_body = 'HI'
+    cmds = ['curl',
+            f'http://localhost:{server_port}/400',
+            '-vvv',
+            ]
+
+    expected_response = RESULT_400
+
+    # When
+    process = await asyncio.create_subprocess_exec(
+        *cmds,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE
+    )
+
+    # Then
+    stdout, stderr = await process.communicate()
+
+    assert stdout.decode() == expected_response
+    assert 'HTTP/1.1 400 Bad Request' in stderr.decode()

--- a/http_2/tests/test_http2_upgrade.py
+++ b/http_2/tests/test_http2_upgrade.py
@@ -2,12 +2,13 @@ import asyncio
 import pytest
 import socket
 
-from ..exception import NeedToChangeProtocolException
-from ..generic_http_object import GenericHttpRequest, GenericHttpResponse
-from ..status_code import StatusCode
-
 from hyperframe.frame import SettingsFrame, HeadersFrame
 from collections import deque
+
+from http_2.exception import NeedToChangeProtocolException
+from http_2.common_http_object import GenericHttpRequest, GenericHttpResponse
+from http_2.status_code import StatusCode
+from http_2.http1_response import GeneralHttp1Response
 from http_2.server import Server, AsyncServerExecutor
 
 
@@ -26,9 +27,7 @@ async def server(server_port):
 
     @http_localhost_server.route(path='/hello/ballo2', methods=['POST', 'GET'])
     async def return_ok(http_request: GenericHttpRequest, http_response: GenericHttpResponse):
-        http_response.status_code = StatusCode.OK
-        http_response.body = RETURN_RESULT
-        return http_response
+        return GeneralHttp1Response(status_code=StatusCode.OK, body=RETURN_RESULT)
 
     executor = AsyncServerExecutor()
     executor.add_server(http_localhost_server)

--- a/http_2/tests/test_streaming_response.py
+++ b/http_2/tests/test_streaming_response.py
@@ -1,0 +1,67 @@
+import asyncio
+import pytest
+import socket
+
+from http_2.server import Server, AsyncServerExecutor
+from http_2.common_http_object import GenericHttpRequest, GenericHttpResponse
+from http_2.http1_response import StreamingResponse
+
+@pytest.fixture
+def server_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(('', 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture
+async def server(server_port):
+    http_localhost_server = Server(server_port)
+
+    @http_localhost_server.get_mapping(path='/subscribe')
+    async def return_ok(http_request: GenericHttpRequest, http_response: GenericHttpResponse):
+        async def gen_contents():
+            for i in range(5):
+                await asyncio.sleep(0.1)
+                yield i
+        return StreamingResponse(gen_contents(), media_type='text/event-stream')
+
+    executor = AsyncServerExecutor()
+    executor.add_server(http_localhost_server)
+
+    await executor.__aenter__()
+    t = asyncio.create_task(executor.execute_forever())
+    await asyncio.sleep(1)
+    yield t
+
+    await executor.__aexit__('', '', '')
+    try:
+        t.cancel()
+        await t
+    except asyncio.CancelledError:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_should_get_streaming_data_and_headers(server_port, server):
+
+    # Given
+    cmds = ['curl',
+            '--no-buffer',
+            f'http://localhost:{server_port}/subscribe',
+            '-vvv',
+            ]
+
+    # When
+    process = await asyncio.create_subprocess_exec(
+        *cmds,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE
+    )
+
+    # Then
+
+    stdout, stderr = await process.communicate()
+
+    assert stdout.decode() == '01234'
+    assert 'HTTP/1.1 200 OK' in stderr.decode()
+    assert 'text/event-stream' in stderr.decode()

--- a/http_2/tests/test_trie.py
+++ b/http_2/tests/test_trie.py
@@ -1,7 +1,7 @@
 import pytest
-from ..data_structure import Trie
 from typing import Callable
 
+from http_2.data_structure import Trie
 
 def test_trie1():
     # When


### PR DESCRIPTION
### Background
The `Server Sent Event` protocol can be operated over the `HTTP/1.1` protocol. 
From now on, the client has a `Server-Sent Events` option, in addition to `polling` and `long polling`. sometimes, `Server Sent Event` may be more useful.